### PR TITLE
Use tagged lifetime scope for collection fixture to provide the abili…

### DIFF
--- a/Sources/Xunit.Autofac/AutofacRegistrationExtensions.cs
+++ b/Sources/Xunit.Autofac/AutofacRegistrationExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autofac.Builder;
+
+namespace Xunit.Autofac
+{
+    public static class AutofacRegistrationExtensions
+    {
+        /// <summary>
+        /// Configure the component so that every dependent component or call to Resolve() within
+        /// a ILifetimeScope assotiated with a test collection gets the same, shared instance.
+        /// Dependent components in lifetime scopes that are children of the tagged scope will
+        /// share the parent's instance.
+        /// </summary>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>
+            InstancePerTestCollection<TLimit, TActivatorData, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> builder)
+        {
+            return builder.InstancePerMatchingLifetimeScope(LifetimeScopeTags.TestCollection);
+        }
+    }
+}

--- a/Sources/Xunit.Autofac/Constants.cs
+++ b/Sources/Xunit.Autofac/Constants.cs
@@ -2,8 +2,8 @@ namespace Xunit.Autofac
 {
     internal static class LifetimeScopeTags
     {
-        private const string Guid = "0463C29A-D9C3-4C1E-8FBB-901E6DE19071";
-        public static readonly object TestAssemblyExecution = nameof(TestAssemblyExecution) + ":" + Guid;
+        private const string TestCollectionGuid = "E55DC22E-F507-4CAF-841E-B62818EF3243";
+        public static readonly object TestCollection = nameof(TestCollection) + ":" + TestCollectionGuid;
     }
 
     internal static class Keys

--- a/Sources/Xunit.Autofac/Execution/AutofacTestAssemblyRunner.cs
+++ b/Sources/Xunit.Autofac/Execution/AutofacTestAssemblyRunner.cs
@@ -27,7 +27,7 @@ namespace Xunit.Autofac.Execution
 
         protected override async Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, CancellationTokenSource cancellationTokenSource)
         {
-            using (var scope = _lifetimeScope.BeginLifetimeScope(cb =>
+            using (var scope = _lifetimeScope.BeginLifetimeScope(LifetimeScopeTags.TestCollection, cb =>
             {
                 cb
                     .RegisterInstance(messageBus)

--- a/Sources/Xunit.Autofac/Execution/AutofacTestCollectionRunner.cs
+++ b/Sources/Xunit.Autofac/Execution/AutofacTestCollectionRunner.cs
@@ -18,9 +18,7 @@ namespace Xunit.Autofac.Execution
             ILifetimeScope lifetimeScope
             ) : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
         {
-            var nestedScope = lifetimeScope.BeginLifetimeScope(LifetimeScopeTags.TestCollection);
-            lifetimeScope.Disposer.AddInstanceForDisposal(nestedScope);
-            _lifetimeScope = nestedScope;
+            _lifetimeScope = lifetimeScope;
         }
 
         protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)

--- a/Sources/Xunit.Autofac/Execution/AutofacTestCollectionRunner.cs
+++ b/Sources/Xunit.Autofac/Execution/AutofacTestCollectionRunner.cs
@@ -18,7 +18,9 @@ namespace Xunit.Autofac.Execution
             ILifetimeScope lifetimeScope
             ) : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
         {
-            _lifetimeScope = lifetimeScope;
+            var nestedScope = lifetimeScope.BeginLifetimeScope(LifetimeScopeTags.TestCollection);
+            lifetimeScope.Disposer.AddInstanceForDisposal(nestedScope);
+            _lifetimeScope = nestedScope;
         }
 
         protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)

--- a/Sources/Xunit.Autofac/Xunit.Autofac.csproj
+++ b/Sources/Xunit.Autofac/Xunit.Autofac.csproj
@@ -67,6 +67,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AutofacRegistrationExtensions.cs" />
     <Compile Include="Execution\AutofacTestAssemblyRunner.cs" />
     <Compile Include="Execution\AutofacTestClassRunner.cs" />
     <Compile Include="Execution\AutofacTestCollectionRunner.cs" />

--- a/Tests/Xunit.Autofac.Usage.Tests/CollectionFixtureTests.cs
+++ b/Tests/Xunit.Autofac.Usage.Tests/CollectionFixtureTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autofac;
+
+namespace Xunit.Autofac.Usage.Tests
+{
+    [Collection(nameof (FixtureCollection))]
+    public class CollectionFixtureTests
+    {
+        private readonly Fixture _fixture;
+        private readonly ComplexObject _complexObject;
+
+        public CollectionFixtureTests(Fixture fixture, ComplexObject complexObject)
+        {
+            _fixture = fixture;
+            _complexObject = complexObject;
+        }
+
+        [Fact]
+        public void CheckReferenceEqualityOfCollectionFixtureObjects()
+        {
+            bool actual = object.ReferenceEquals(_fixture, _complexObject?.Fixture);
+
+            Assert.NotNull(_fixture);
+            Assert.NotNull(_complexObject);
+            Assert.NotNull(_complexObject.Fixture);
+            Assert.True(actual);
+        }
+    }
+
+    public class Fixture
+    {
+    }
+
+    public class ComplexObject
+    {
+        public Fixture Fixture { get; }
+
+        public ComplexObject(Fixture fixture)
+        {
+            Fixture = fixture;
+        }
+    }
+
+    [CollectionDefinition(nameof (FixtureCollection))]
+    public class FixtureCollection : ICollectionFixture<Fixture>
+    {
+    }
+
+    // ReSharper disable once UnusedMember.Global
+    public class ServiceRegistration : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder
+                .RegisterType<Fixture>()
+                .AsSelf()
+                .InstancePerTestCollection();
+
+            builder
+                .RegisterType<ComplexObject>()
+                .AsSelf()
+                .InstancePerTestCollection();
+        }
+    }
+}

--- a/Tests/Xunit.Autofac.Usage.Tests/Xunit.Autofac.Usage.Tests.csproj
+++ b/Tests/Xunit.Autofac.Usage.Tests/Xunit.Autofac.Usage.Tests.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -60,6 +63,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CollectionFixtureTests.cs" />
     <Compile Include="SimpleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="XBehave.cs" />

--- a/Tests/Xunit.Autofac.Usage.Tests/packages.config
+++ b/Tests/Xunit.Autofac.Usage.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Autofac" version="4.3.0" targetFramework="net452" />
   <package id="Xbehave.Core" version="2.1.4" targetFramework="net452" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />


### PR DESCRIPTION
Use tagged lifetime scope for collection fixture to provide the ability to share a single instance within a test collection